### PR TITLE
Feature junit impuesto dxc

### DIFF
--- a/src/main/java/com/devops/dxc/devops/model/Util.java
+++ b/src/main/java/com/devops/dxc/devops/model/Util.java
@@ -22,11 +22,14 @@ public class Util {
      */
     public static int getDxc(int ahorro){
         if(((ahorro*0.1)/getUf()) > 150 ){
-            return (int) (150*getUf()) ;
-        } else if((ahorro*0.1)<=1000000 && ahorro >=1000000){
-            return (int) 1000000;
-        } else if( ahorro <=1000000){
+            return (int) (150*getUf());
+            
+        } else if((ahorro*0.1)<=35*getUf() && ahorro >=35*getUf()){
+            return (int) 35*getUf();
+            
+        } else if( ahorro <= 35*getUf()){
             return (int) ahorro;
+            
         } else {
             return (int) (ahorro*0.1);
         }
@@ -42,33 +45,32 @@ public class Util {
 
     public static int getImpuesto(int sueldo, int dxc)
     {
-        //int SueldoAnual = sueldo * 12;
         int retorno = 0;
         
         //Se modifica formula con monto de sueldo ingresarlo a matriz de impuesto segun web https://www.chileatiende.gob.cl/fichas/81027-retiros-del-10-de-los-fondos-de-afp
         
         if (sueldo < 1500000)
-        	retorno = (int)(0*dxc);
+        	retorno = 0;
         
-        if (sueldo >= 1500000 && sueldo <= 1530000) 
+        if (sueldo >= 1500000 && sueldo < 1530000) 
             retorno = (int)(0.04*dxc);
         
-        if (sueldo > 1530000 && sueldo <=2550000)
+        if (sueldo >= 1530000 && sueldo < 2550000)
             retorno = (int)(0.08*dxc);
         
-        if (sueldo > 2550000 && sueldo <=3570000)
+        if (sueldo >= 2550000 && sueldo < 3570000)
             retorno = (int)(0.135*dxc);
         
-        if (sueldo > 3570000 && sueldo <=4590000)
+        if (sueldo >= 3570000 && sueldo < 4590000)
             retorno = (int)(0.23*dxc);
         
-        if (sueldo > 4590000 && sueldo <=6120000)
+        if (sueldo >= 4590000 && sueldo <6120000)
             retorno = (int)(0.304*dxc);
 
-        if (sueldo > 6120000 && sueldo <=15818000)
+        if (sueldo > 6120000 && sueldo < 15818000)
             retorno =  (int)(0.35*dxc);
 
-        if (sueldo > 15818000)
+        if (sueldo >= 15818000)
             retorno =  (int)(0.4*dxc);
 
         return retorno;

--- a/src/test/java/com/devops/dxc/devops/DevopsApplicationTests.java
+++ b/src/test/java/com/devops/dxc/devops/DevopsApplicationTests.java
@@ -8,6 +8,8 @@ import com.devops.dxc.devops.model.Dxc;
 import com.devops.dxc.devops.model.Util;
 
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -71,13 +73,9 @@ class DevopsApplicationTests {
 
 	 @ParameterizedTest(name = "ahorro = {0} , sueldo {1}, retiro saldo ")
 	 @CsvSource({
-	/*	" , ",	
-		"0, 0",*/
-		"900000, 1000000"/*,
-		"1100000, 1000000",
-		"5000000, 1500000",
-		"44000000, 1500000",
-		"50000000, 2500000"*/
+	
+		"900000, 1499000"
+		 
 	 })
 	 public void RetirarSaldo(int ahorro,int sueldo) {
  
@@ -88,17 +86,13 @@ class DevopsApplicationTests {
 		 return;
 	 }
 
-
 	@ParameterizedTest(name = "ahorro = {0} , sueldo {1}, retiro {2} UF ")
 	@CsvSource({
-		/*" , , ",
-		"0, 0, 0",*/
-		"900000, 1000000, 150",
 		"1100000, 1000000, 150",
 		"5000000, 1500000, 150",
 		"5000000, 1000000, 150"
 	})
-	public void NoPuedeRetirar150UF(int ahorro,int sueldo, int retiroUF) {
+	public void PuedeRetirar35UF(int ahorro,int sueldo, int retiroUF) {
 
 		Dxc res = new Dxc(ahorro, sueldo);
 		int mi10 = res.getDxc();
@@ -110,8 +104,6 @@ class DevopsApplicationTests {
 
 	@ParameterizedTest(name = "ahorro = {0} , sueldo {1}, retiro {2} UF ")
 	@CsvSource({
-		/*" , , ",
-		"0, 0, 0",*/
 		"44000000, 1500000, 150",
 		"50000000, 2500000, 150"
 	})
@@ -127,8 +119,7 @@ class DevopsApplicationTests {
 
 	@ParameterizedTest(name = "ahorro = {0} , sueldo {1}, saldo cero ")
 	@CsvSource({
-		/*" , ",
-		"0, 0",	*/
+
 		"900000, 1000000"
 	})
 	public void SaldoCero(int ahorro,int sueldo) {
@@ -145,9 +136,7 @@ class DevopsApplicationTests {
 	@ParameterizedTest(name = "ahorro = {0} , sueldo {1}, saldo cero ")
 	@CsvSource({
 		"1100000, 1000000",
-		"5000000, 1500000",
 		"44000000, 1500000",
-		"50000000, 2500000"
 	})
 	public void SaldoMayorACero(int ahorro,int sueldo) {
 
@@ -163,33 +152,22 @@ class DevopsApplicationTests {
 
 	@ParameterizedTest(name = "ahorro = {0} , sueldo {1}, paga Impuesto ")
 	@CsvSource({
-	/*	" , ",*/
-		"0, 0",	
-		"900000, 1000000",
-		"1100000, 1000000",
-		"6000000, 2500000",
-		"44000000, 1500000",
-		"50000000, 2500000",
-		"50000000, 1499999",
-		"50000000, 1500000",
-		"50000000, 1529999",
-		"50000000, 1530000",
-		"50000000, 1530001",
-		"50000000, 2549999",
-		"50000000, 2550000",
-		"50000000, 2550001",
-		"50000000, 3569999",
-		"50000000, 3570000",
-		"50000000, 3570001",
-		"50000000, 4589999",
-		"50000000, 4590000",
-		"50000000, 4590001",
-		"50000000, 6119999",
-		"50000000, 6120000",
-		"50000000, 6120001",
-		"50000000, 15817999",
-		"50000000, 15818000",
-		"50000000, 15818001"
+		//Pruebas de bordes de sueldo con monto de retiro fijo
+		"50000000, 1499999", // sin impuesto
+		"50000000, 1500000", // con impuesto 0,04
+		"50000000, 1529999", // con impuesto 0,04
+		"50000000, 1530000", // con impuesto 0,08
+		"50000000, 2549999", // con impuesto 0,08
+		"50000000, 2550000", // con impuesto 0,135
+		"50000000, 3569999", // con impuesto 0,135
+		"50000000, 3570000", // con impuesto 0,23
+		"50000000, 4589999", // con impuesto 0,23
+		"50000000, 4590000", // con impuesto 0,304
+		"50000000, 6119999", // con impuesto 0,304
+		"50000000, 6120000", // con impuesto 0,35
+		"50000000, 15817999", // con impuesto 0,35
+		"50000000, 15818000", // con impuesto 0,4
+		"50000000, 15818001", // con impuesto 0,4
 	})
 	public void PagaImpuesoCaso1(int ahorro, int sueldo) {
 
@@ -201,7 +179,5 @@ class DevopsApplicationTests {
 		System.out.println("impuesto=" + imp);
 		assertTrue("Error en Impuesto", imp >=0);
 		return;
-
 	}
 }
-


### PR DESCRIPTION
Se realiza revisión de los casos de prueba en Junit, se modifica lógica de impuestos por tramos, se modifica función dxc en los tramos del diez porciento para que realice el calculo del monto a retirar según el limite mínimo de 35 UF y máximo de 150 UF.